### PR TITLE
Clear both GL buffers

### DIFF
--- a/imageOpenGL.py
+++ b/imageOpenGL.py
@@ -76,6 +76,8 @@ class ImageOpenGL(ImageBase):
         glEnable(GL_TEXTURE_2D)
         glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_REPLACE)
         glClear(GL_COLOR_BUFFER_BIT)
+        glutSwapBuffers()
+        glClear(GL_COLOR_BUFFER_BIT)
 
     def glutcb_display(self):
         """ Draws the image as the simulation runs """


### PR DESCRIPTION
Added code to clear the 2nd buffer so that when the buffers are swapped, there won't be an annoying flash between the two.  This was tested on OS X 10.10 (GM 3).
